### PR TITLE
Support for variables and conneciton params

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -7,6 +7,19 @@ module ActiveRecord
       @connection = ActiveRecord::Base.connection
     end
 
+    def test_passing_connection_info
+      config = { connect_timeout: 123, not_a_valid_param: 'hello' }
+      output = @connection.send(:collect_connection_params, config)
+      assert_equal output.first[:port], 5432
+      assert_equal output.first[:connect_timeout], 123
+      assert_nil output.first[:not_a_valid_param]
+    end
+
+    def test_variables
+      result = @connection.execute("show statement_timeout").to_a
+      assert_equal result.first["statement_timeout"], "90s"
+    end
+
     def test_encoding
       assert_not_nil @connection.encoding
     end

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -111,9 +111,13 @@ connections:
 
   postgresql:
     arunit:
+      variables:
+        statement_timeout: 90s
       min_messages: warning
     arunit2:
       min_messages: warning
+      variables:
+        statement_timeout: 90s
 
   sqlite3:
     arunit:


### PR DESCRIPTION
This pulls in two features of ActiveRecord 4.2. Mainly the ability to
specify connect_timeout (and other connection params) as well as the
ability to specify variables. Both of which are only in 4.2. This is
should be compatible with postgis adapter 0.6.6 and the makara gem.
